### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/NordPass/NordPass_Universal.pkg.recipe.yaml
+++ b/NordPass/NordPass_Universal.pkg.recipe.yaml
@@ -37,7 +37,6 @@ Process:
             path: Applications/%bundle_name%.app
             user: root
         id: "%bundle_id%.intel"
-        options: purge_ds_store
         pkgname: "%bundle_name%_Intel-%bundle_version%"
         pkgroot: "%RECIPE_CACHE_DIR%/Intel"
         version: "%bundle_version%"
@@ -70,7 +69,6 @@ Process:
             path: Applications/%bundle_name%.app
             user: root
         id: "%bundle_id%.silicon"
-        options: purge_ds_store
         pkgname: "%bundle_name%_Silicon-%bundle_version%"
         pkgroot: "%RECIPE_CACHE_DIR%/Silicon"
         version: "%bundle_version%"
@@ -134,7 +132,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%bundle_id%.Universal"
-        options: purge_ds_store
         pkgname: "%bundle_name%_Universal-%bundle_version%"
         pkgroot: "%RECIPE_CACHE_DIR%/Universal/root"
         scripts: "%RECIPE_CACHE_DIR%/Universal/scripts"


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._